### PR TITLE
feat: capability permission sandbox (--sandbox/--allow-*/--deny-*)

### DIFF
--- a/crates/fastnode-cli/src/commands/run.rs
+++ b/crates/fastnode-cli/src/commands/run.rs
@@ -46,9 +46,19 @@ pub fn run(
     native: bool,
     node: bool,
     local: bool,
+    permissions: &crate::PermissionFlags,
     channel: Channel,
     json: bool,
 ) -> Result<()> {
+    // Permissions only apply to the native runtime path. Warn (rather than
+    // silently ignore) if a sandbox was requested for a path that can't enforce it.
+    if permissions.any_set() && (daemon || node) {
+        eprintln!(
+            "warning: permission flags (--sandbox/--allow-*/--deny-*) are ignored \
+             when running via {} — they apply to the native runtime only",
+            if daemon { "--daemon" } else { "--node" }
+        );
+    }
     // First, check if entry is a package.json script
     if let Some(script_cmd) = get_package_script(cwd, entry) {
         return run_script(cwd, entry, &script_cmd, args, json);
@@ -63,7 +73,7 @@ pub fn run(
         // --node forces Node.js subprocess
         // Otherwise use native (either explicitly via --native or by default)
         if !node {
-            return run_native(cwd, entry_path, args, local, json);
+            return run_native(cwd, entry_path, args, local, permissions, json);
         }
         // Fall through to Node.js execution
     }
@@ -163,11 +173,91 @@ fn run_script(
     std::process::exit(status.code().unwrap_or(1));
 }
 
+/// Parse a `--allow-X` value into a scope: empty (`--allow-X` with no value)
+/// means "all" (`None`); otherwise split the comma list into an allowlist.
+#[cfg(feature = "native-runtime")]
+fn parse_scope(value: &str) -> Option<Vec<String>> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(
+            value
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+        )
+    }
+}
+
+/// Convert CLI permission flags into a runtime `Permissions` set. Returns `None`
+/// when no flag was given, preserving the zero-overhead allow-all default.
+///
+/// Precedence: base (`--sandbox` = deny-all, else allow-all) → `--allow-*`
+/// grants/restrictions → `--deny-*` revocations (deny always wins).
+#[cfg(feature = "native-runtime")]
+fn build_permissions(flags: &crate::PermissionFlags) -> Option<fastnode_runtime::Permissions> {
+    use fastnode_runtime::Permissions;
+
+    if !flags.any_set() {
+        return None;
+    }
+
+    let mut p = if flags.sandbox {
+        Permissions::sandboxed()
+    } else {
+        Permissions::allow_all()
+    };
+
+    if let Some(v) = &flags.allow_read {
+        p = p.allow_read(parse_scope(v));
+    }
+    if let Some(v) = &flags.allow_write {
+        p = p.allow_write(parse_scope(v));
+    }
+    if let Some(v) = &flags.allow_net {
+        p = p.allow_net(parse_scope(v));
+    }
+    if let Some(v) = &flags.allow_run {
+        p = p.allow_run(parse_scope(v));
+    }
+    if let Some(v) = &flags.allow_env {
+        p = p.allow_env(parse_scope(v));
+    }
+
+    if flags.deny_read {
+        p = p.deny_read();
+    }
+    if flags.deny_write {
+        p = p.deny_write();
+    }
+    if flags.deny_net {
+        p = p.deny_net();
+    }
+    if flags.deny_run {
+        p = p.deny_run();
+    }
+    if flags.deny_env {
+        p = p.deny_env();
+    }
+
+    Some(p)
+}
+
 /// Run using native V8 runtime (no Node.js subprocess).
 /// When `local` is true, runs within a LocalSet for same-thread HTTP handling.
 #[cfg(feature = "native-runtime")]
-fn run_native(cwd: &Path, entry: &Path, args: &[String], local: bool, json: bool) -> Result<()> {
+fn run_native(
+    cwd: &Path,
+    entry: &Path,
+    args: &[String],
+    local: bool,
+    permissions: &crate::PermissionFlags,
+    json: bool,
+) -> Result<()> {
     use fastnode_runtime::{create_local_server_future, Runtime, RuntimeOptions};
+
+    let permissions = build_permissions(permissions);
 
     // Resolve entry path
     let entry_path = if entry.is_absolute() {
@@ -201,6 +291,7 @@ fn run_native(cwd: &Path, entry: &Path, args: &[String], local: bool, json: bool
                 cwd: Some(cwd.to_path_buf()),
                 main_module: Some(entry_path.clone()),
                 args: Some(script_args),
+                permissions: permissions.clone(),
                 ..Default::default()
             })
             .map_err(|e| miette::miette!("Failed to create runtime: {}", e))?;
@@ -238,6 +329,7 @@ fn run_native(cwd: &Path, entry: &Path, args: &[String], local: bool, json: bool
                 cwd: Some(cwd.to_path_buf()),
                 main_module: Some(entry_path.clone()),
                 args: Some(script_args),
+                permissions: permissions.clone(),
                 ..Default::default()
             })
             .map_err(|e| miette::miette!("Failed to create runtime: {}", e))?;

--- a/crates/fastnode-cli/src/main.rs
+++ b/crates/fastnode-cli/src/main.rs
@@ -52,6 +52,71 @@ struct Cli {
     command: Option<Commands>,
 }
 
+/// Capability flags for `howth run`. howth is allow-all by default (Node
+/// compatible); these opt into a sandbox or selectively revoke access.
+///
+/// For each capability, `--allow-X` with no value permits everything, and
+/// `--allow-X=a,b` restricts it to a comma-separated allowlist. `--deny-X`
+/// revokes it entirely (applied after any allow). Path capabilities match by
+/// prefix; net entries are `host` or `host:port`; env/run entries are exact.
+#[derive(clap::Args, Debug, Clone, Default)]
+pub struct PermissionFlags {
+    /// Deny all capabilities by default; grant back with --allow-* flags.
+    #[arg(long, help_heading = "Permissions")]
+    pub sandbox: bool,
+
+    /// Allow filesystem reads (optionally restrict to =PATHS).
+    #[arg(long, value_name = "PATHS", num_args = 0..=1, default_missing_value = "", help_heading = "Permissions")]
+    pub allow_read: Option<String>,
+    /// Allow filesystem writes (optionally restrict to =PATHS).
+    #[arg(long, value_name = "PATHS", num_args = 0..=1, default_missing_value = "", help_heading = "Permissions")]
+    pub allow_write: Option<String>,
+    /// Allow network access (optionally restrict to =HOSTS, e.g. api.example.com:443).
+    #[arg(long, value_name = "HOSTS", num_args = 0..=1, default_missing_value = "", help_heading = "Permissions")]
+    pub allow_net: Option<String>,
+    /// Allow spawning subprocesses (optionally restrict to =CMDS).
+    #[arg(long, value_name = "CMDS", num_args = 0..=1, default_missing_value = "", help_heading = "Permissions")]
+    pub allow_run: Option<String>,
+    /// Allow environment access (optionally restrict to =VARS).
+    #[arg(long, value_name = "VARS", num_args = 0..=1, default_missing_value = "", help_heading = "Permissions")]
+    pub allow_env: Option<String>,
+
+    /// Deny all filesystem reads.
+    #[arg(long, help_heading = "Permissions")]
+    pub deny_read: bool,
+    /// Deny all filesystem writes.
+    #[arg(long, help_heading = "Permissions")]
+    pub deny_write: bool,
+    /// Deny all network access.
+    #[arg(long, help_heading = "Permissions")]
+    pub deny_net: bool,
+    /// Deny spawning subprocesses.
+    #[arg(long, help_heading = "Permissions")]
+    pub deny_run: bool,
+    /// Deny environment access.
+    #[arg(long, help_heading = "Permissions")]
+    pub deny_env: bool,
+}
+
+impl PermissionFlags {
+    /// True if any permission flag was set (so we can keep the zero-overhead
+    /// allow-all path when none are).
+    #[must_use]
+    pub fn any_set(&self) -> bool {
+        self.sandbox
+            || self.allow_read.is_some()
+            || self.allow_write.is_some()
+            || self.allow_net.is_some()
+            || self.allow_run.is_some()
+            || self.allow_env.is_some()
+            || self.deny_read
+            || self.deny_write
+            || self.deny_net
+            || self.deny_run
+            || self.deny_env
+    }
+}
+
 #[derive(clap::Subcommand, Debug)]
 enum Commands {
     /// Print version information
@@ -135,6 +200,9 @@ enum Commands {
         /// Run in LocalSet mode (HTTP + JS on same thread for max performance)
         #[arg(long)]
         local: bool,
+
+        #[command(flatten)]
+        permissions: PermissionFlags,
 
         /// Arguments to pass to the script (after --)
         #[arg(last = true)]
@@ -685,6 +753,7 @@ fn main() -> Result<()> {
                 false, // native
                 false, // node
                 false, // local
+                &PermissionFlags::default(),
                 Channel::Stable,
                 cli.json,
             );
@@ -748,6 +817,7 @@ fn main() -> Result<()> {
         native,
         node,
         local,
+        permissions,
         args,
     }) = &cli.command
     {
@@ -760,6 +830,7 @@ fn main() -> Result<()> {
             *native,
             *node,
             *local,
+            permissions,
             Channel::Stable,
             cli.json,
         );
@@ -1014,6 +1085,7 @@ fn main() -> Result<()> {
                     false, // native
                     false, // node
                     false, // local
+                    &PermissionFlags::default(),
                     Channel::Stable,
                     cli.json,
                 );

--- a/crates/fastnode-runtime/src/lib.rs
+++ b/crates/fastnode-runtime/src/lib.rs
@@ -23,9 +23,11 @@
 mod module_loader;
 pub mod napi;
 mod ops;
+pub mod permissions;
 mod runtime;
 
 pub use module_loader::{HowthModuleLoader, VirtualModuleMap};
+pub use permissions::Permissions;
 pub use runtime::{create_local_server_future, Runtime, RuntimeError, RuntimeOptions};
 
 /// Run a JavaScript file and return the exit code.

--- a/crates/fastnode-runtime/src/permissions.rs
+++ b/crates/fastnode-runtime/src/permissions.rs
@@ -1,0 +1,407 @@
+//! Capability-based permissions for the howth runtime.
+//!
+//! howth is a Node-compatible runtime, so the default posture is **allow-all**
+//! (Node code assumes unrestricted access to fs/net/env/subprocesses). Users
+//! opt *into* a sandbox with `--sandbox` (deny-by-default) plus `--allow-*`
+//! grants, or selectively revoke with `--deny-*`.
+//!
+//! Permissions are set once at startup and are read-only thereafter, so they
+//! live in a process-global `OnceLock` — the same idiom the runtime already
+//! uses for `SCRIPT_ARGS`. Boundary ops gate themselves with a single call:
+//!
+//! ```ignore
+//! permissions::get().check_read(path)?;
+//! ```
+//!
+//! Per-worker permission sets (for multi-tenant isolation) would instead live
+//! in `OpState`; that is a deliberate future refinement, not what ships here.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
+
+use deno_core::error::AnyError;
+
+/// A single capability's grant.
+#[derive(Debug, Clone)]
+enum Scope {
+    /// Unrestricted (the Node-compatible default).
+    All,
+    /// Restricted to an explicit allowlist. For paths, entries are normalized
+    /// absolute prefixes; for net, `host` or `host:port`; for env/run, exact keys.
+    List(HashSet<String>),
+    /// Fully denied.
+    None,
+}
+
+impl Scope {
+    /// Build a scope from an optional allowlist:
+    /// - `None`         → `Scope::All`   (flag absent → capability unrestricted)
+    /// - `Some(empty)`  → `Scope::All`   (`--allow-read` with no value → all)
+    /// - `Some(values)` → `Scope::List`  (`--allow-read=/a,/b` → allowlist)
+    fn from_allow(values: Option<Vec<String>>) -> Self {
+        match values {
+            None => Scope::All,
+            Some(v) if v.is_empty() => Scope::All,
+            Some(v) => Scope::List(v.into_iter().collect()),
+        }
+    }
+}
+
+/// The full permission set for a runtime process.
+#[derive(Debug, Clone)]
+pub struct Permissions {
+    read: Scope,
+    write: Scope,
+    net: Scope,
+    run: Scope,
+    env: Scope,
+}
+
+impl Default for Permissions {
+    /// Allow-all — the Node-compatible default. Nothing is gated until the user
+    /// asks for a sandbox.
+    fn default() -> Self {
+        Permissions {
+            read: Scope::All,
+            write: Scope::All,
+            net: Scope::All,
+            run: Scope::All,
+            env: Scope::All,
+        }
+    }
+}
+
+impl Permissions {
+    /// Explicit allow-all (same as `default`), for readability at call sites.
+    #[must_use]
+    pub fn allow_all() -> Self {
+        Permissions::default()
+    }
+
+    /// Sandboxed base: everything denied. Callers then grant with the
+    /// `allow_*` builders. This is what `--sandbox` selects.
+    #[must_use]
+    pub fn sandboxed() -> Self {
+        Permissions {
+            read: Scope::None,
+            write: Scope::None,
+            net: Scope::None,
+            run: Scope::None,
+            env: Scope::None,
+        }
+    }
+
+    /// Grant read access. `None` = all paths, `Some(list)` = allowlist.
+    #[must_use]
+    pub fn allow_read(mut self, paths: Option<Vec<String>>) -> Self {
+        self.read = Scope::from_allow(paths.map(normalize_prefixes));
+        self
+    }
+
+    /// Grant write access. `None` = all paths, `Some(list)` = allowlist.
+    #[must_use]
+    pub fn allow_write(mut self, paths: Option<Vec<String>>) -> Self {
+        self.write = Scope::from_allow(paths.map(normalize_prefixes));
+        self
+    }
+
+    /// Grant network access. `None` = all, `Some(list)` = `host`/`host:port` allowlist.
+    #[must_use]
+    pub fn allow_net(mut self, hosts: Option<Vec<String>>) -> Self {
+        self.net = Scope::from_allow(hosts);
+        self
+    }
+
+    /// Grant subprocess spawning. `None` = all, `Some(list)` = command allowlist.
+    #[must_use]
+    pub fn allow_run(mut self, cmds: Option<Vec<String>>) -> Self {
+        self.run = Scope::from_allow(cmds);
+        self
+    }
+
+    /// Grant env access. `None` = all, `Some(list)` = variable-name allowlist.
+    #[must_use]
+    pub fn allow_env(mut self, keys: Option<Vec<String>>) -> Self {
+        self.env = Scope::from_allow(keys);
+        self
+    }
+
+    /// Revoke a capability entirely (`--deny-*`). Applied after grants.
+    #[must_use]
+    pub fn deny_read(mut self) -> Self {
+        self.read = Scope::None;
+        self
+    }
+    #[must_use]
+    pub fn deny_write(mut self) -> Self {
+        self.write = Scope::None;
+        self
+    }
+    #[must_use]
+    pub fn deny_net(mut self) -> Self {
+        self.net = Scope::None;
+        self
+    }
+    #[must_use]
+    pub fn deny_run(mut self) -> Self {
+        self.run = Scope::None;
+        self
+    }
+    #[must_use]
+    pub fn deny_env(mut self) -> Self {
+        self.env = Scope::None;
+        self
+    }
+
+    // --- Checks (called from boundary ops) ---
+
+    /// Permit reading `path`, or return a descriptive error naming the flag to add.
+    pub fn check_read(&self, path: &str) -> Result<(), AnyError> {
+        check_path(&self.read, path, "read from", "--allow-read")
+    }
+
+    /// Permit writing `path`, or error.
+    pub fn check_write(&self, path: &str) -> Result<(), AnyError> {
+        check_path(&self.write, path, "write to", "--allow-write")
+    }
+
+    /// Permit connecting/binding to `host:port`, or error.
+    pub fn check_net(&self, host: &str, port: u16) -> Result<(), AnyError> {
+        match &self.net {
+            Scope::All => Ok(()),
+            Scope::None => Err(denied(&format!("network access to \"{host}:{port}\""), "--allow-net")),
+            Scope::List(set) => {
+                if set.contains(host) || set.contains(&format!("{host}:{port}")) {
+                    Ok(())
+                } else {
+                    Err(denied(
+                        &format!("network access to \"{host}:{port}\""),
+                        "--allow-net",
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Permit host-level network access (DNS resolution, or a fetch whose port
+    /// is implied by scheme). Matches a bare-host grant or any `host:port` grant
+    /// for that host.
+    pub fn check_net_host(&self, host: &str) -> Result<(), AnyError> {
+        match &self.net {
+            Scope::All => Ok(()),
+            Scope::None => Err(denied(&format!("network access to \"{host}\""), "--allow-net")),
+            Scope::List(set) => {
+                let prefix = format!("{host}:");
+                if set.contains(host) || set.iter().any(|e| e.starts_with(&prefix)) {
+                    Ok(())
+                } else {
+                    Err(denied(&format!("network access to \"{host}\""), "--allow-net"))
+                }
+            }
+        }
+    }
+
+    /// Permit spawning `cmd`, or error. Matches the allowlist against the full
+    /// command, its basename, its first whitespace-delimited token (the program
+    /// name in a shell string like `"echo hi"`), and that token's basename.
+    pub fn check_run(&self, cmd: &str) -> Result<(), AnyError> {
+        match &self.run {
+            Scope::All => Ok(()),
+            Scope::None => Err(denied(&format!("running subprocess \"{cmd}\""), "--allow-run")),
+            Scope::List(set) => {
+                let basename = |s: &str| {
+                    Path::new(s)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or(s)
+                        .to_string()
+                };
+                let first_token = cmd.split_whitespace().next().unwrap_or(cmd);
+                let candidates = [
+                    cmd.to_string(),
+                    basename(cmd),
+                    first_token.to_string(),
+                    basename(first_token),
+                ];
+                if candidates.iter().any(|c| set.contains(c)) {
+                    Ok(())
+                } else {
+                    Err(denied(
+                        &format!("running subprocess \"{cmd}\""),
+                        "--allow-run",
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Permit reading/writing env var `key`, or error.
+    pub fn check_env(&self, key: &str) -> Result<(), AnyError> {
+        match &self.env {
+            Scope::All => Ok(()),
+            Scope::None => Err(denied(&format!("access to env variable \"{key}\""), "--allow-env")),
+            Scope::List(set) => {
+                if set.contains(key) {
+                    Ok(())
+                } else {
+                    Err(denied(&format!("access to env variable \"{key}\""), "--allow-env"))
+                }
+            }
+        }
+    }
+}
+
+/// Process-global permission set. Installed once by `init` before any JS runs.
+static PERMISSIONS: OnceLock<Permissions> = OnceLock::new();
+
+/// Install the process permission set. Call once, before executing user code.
+/// Subsequent calls are ignored (the first set wins), matching `SCRIPT_ARGS`.
+pub fn init(perms: Permissions) {
+    let _ = PERMISSIONS.set(perms);
+}
+
+/// Get the active permissions. Falls back to allow-all if `init` was never
+/// called (e.g. embedded/library use), preserving Node-compatible behavior.
+pub fn get() -> &'static Permissions {
+    static DEFAULT: OnceLock<Permissions> = OnceLock::new();
+    PERMISSIONS
+        .get()
+        .unwrap_or_else(|| DEFAULT.get_or_init(Permissions::default))
+}
+
+/// Check a path against a path scope. Allowlist entries are normalized absolute
+/// prefixes; access is granted if the (normalized) target is under any of them.
+fn check_path(scope: &Scope, path: &str, action: &str, flag: &str) -> Result<(), AnyError> {
+    match scope {
+        Scope::All => Ok(()),
+        Scope::None => Err(denied(&format!("{action} \"{path}\""), flag)),
+        Scope::List(set) => {
+            let target = normalize(path);
+            if set.iter().any(|allowed| target.starts_with(Path::new(allowed))) {
+                Ok(())
+            } else {
+                Err(denied(&format!("{action} \"{path}\""), flag))
+            }
+        }
+    }
+}
+
+/// Build a `PermissionDenied` error whose message tells the user which flag grants access.
+fn denied(what: &str, flag: &str) -> AnyError {
+    AnyError::msg(format!(
+        "PermissionDenied: requires {what}. Run with {flag} to grant access."
+    ))
+}
+
+/// Normalize a set of path prefixes to absolute, lexically-cleaned form for storage.
+fn normalize_prefixes(paths: Vec<String>) -> Vec<String> {
+    paths
+        .into_iter()
+        .map(|p| normalize(&p).to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Resolve a path to an absolute, lexically-cleaned `PathBuf` without touching
+/// the filesystem (no symlink resolution — purely syntactic, like the resolver's
+/// `normalize_path`). This keeps checks cheap and side-effect free.
+fn normalize(p: &str) -> PathBuf {
+    let path = Path::new(p);
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+
+    let mut out = PathBuf::new();
+    for comp in abs.components() {
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_all_default_permits_everything() {
+        let p = Permissions::allow_all();
+        assert!(p.check_read("/etc/passwd").is_ok());
+        assert!(p.check_write("/tmp/x").is_ok());
+        assert!(p.check_net("example.com", 443).is_ok());
+        assert!(p.check_run("rm").is_ok());
+        assert!(p.check_env("HOME").is_ok());
+    }
+
+    #[test]
+    fn sandboxed_denies_everything() {
+        let p = Permissions::sandboxed();
+        assert!(p.check_read("/tmp/x").is_err());
+        assert!(p.check_write("/tmp/x").is_err());
+        assert!(p.check_net("example.com", 443).is_err());
+        assert!(p.check_run("rm").is_err());
+        assert!(p.check_env("HOME").is_err());
+    }
+
+    #[test]
+    fn read_allowlist_matches_by_prefix() {
+        let p = Permissions::sandboxed().allow_read(Some(vec!["/app".into()]));
+        assert!(p.check_read("/app/src/index.js").is_ok());
+        assert!(p.check_read("/app").is_ok());
+        assert!(p.check_read("/etc/passwd").is_err());
+        // A sibling that merely shares a name prefix must NOT match.
+        assert!(p.check_read("/application/secret").is_err());
+    }
+
+    #[test]
+    fn net_allowlist_matches_host_or_host_port() {
+        let p = Permissions::sandboxed().allow_net(Some(vec![
+            "api.example.com".into(),
+            "db.internal:5432".into(),
+        ]));
+        assert!(p.check_net("api.example.com", 443).is_ok()); // host-only grant, any port
+        assert!(p.check_net("db.internal", 5432).is_ok()); // exact host:port
+        assert!(p.check_net("db.internal", 5433).is_err()); // wrong port
+        assert!(p.check_net("evil.com", 443).is_err());
+    }
+
+    #[test]
+    fn run_allowlist_matches_basename() {
+        let p = Permissions::sandboxed().allow_run(Some(vec!["git".into()]));
+        assert!(p.check_run("git").is_ok());
+        assert!(p.check_run("/usr/bin/git").is_ok());
+        assert!(p.check_run("rm").is_err());
+    }
+
+    #[test]
+    fn run_allowlist_matches_shell_command_first_token() {
+        // execSync("echo hi") passes the whole shell string; the program is the first token.
+        let p = Permissions::sandboxed().allow_run(Some(vec!["echo".into()]));
+        assert!(p.check_run("echo hi").is_ok());
+        assert!(p.check_run("/bin/echo hi there").is_ok());
+        assert!(p.check_run("rm -rf /").is_err());
+    }
+
+    #[test]
+    fn env_allowlist_is_exact() {
+        let p = Permissions::sandboxed().allow_env(Some(vec!["PATH".into()]));
+        assert!(p.check_env("PATH").is_ok());
+        assert!(p.check_env("SECRET").is_err());
+    }
+
+    #[test]
+    fn empty_allow_list_means_all() {
+        // `--allow-read` with no value grants everything.
+        let p = Permissions::sandboxed().allow_read(Some(vec![]));
+        assert!(p.check_read("/anywhere").is_ok());
+    }
+}

--- a/crates/fastnode-runtime/src/runtime.rs
+++ b/crates/fastnode-runtime/src/runtime.rs
@@ -117,6 +117,8 @@ pub struct RuntimeOptions {
     pub args: Option<Vec<String>>,
     /// Virtual modules served from memory instead of disk.
     pub virtual_modules: Option<crate::module_loader::VirtualModuleMap>,
+    /// Capability permissions. `None` = allow-all (Node-compatible default).
+    pub permissions: Option<crate::permissions::Permissions>,
 }
 
 /// Thread-local storage for script arguments (set before runtime creation).
@@ -325,6 +327,7 @@ fn op_howth_print_error(#[string] msg: &str) {
 #[op2]
 #[string]
 fn op_howth_read_file(#[string] path: &str) -> Result<String, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     let bytes = std::fs::read(path).map_err(|e| format_fs_error(e, "open", path))?;
     match String::from_utf8(bytes) {
         Ok(s) => Ok(s),
@@ -338,12 +341,17 @@ fn op_howth_write_file(
     #[string] path: &str,
     #[string] contents: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     std::fs::write(path, contents).map_err(|e| format_fs_error(e, "open", path))
 }
 
 /// Check if a file or directory exists.
 #[op2(fast)]
 fn op_howth_fs_exists(#[string] path: &str) -> bool {
+    // Probing existence is a read; a denied read reports "does not exist".
+    if crate::permissions::get().check_read(path).is_err() {
+        return false;
+    }
     std::path::Path::new(path).exists()
 }
 
@@ -353,6 +361,7 @@ fn op_howth_fs_mkdir(
     #[string] path: &str,
     recursive: bool,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     if recursive {
         std::fs::create_dir_all(path).map_err(|e| format_fs_error(e, "mkdir", path))
     } else {
@@ -373,6 +382,7 @@ pub struct DirEntry {
 #[op2]
 #[serde]
 fn op_howth_fs_readdir(#[string] path: &str) -> Result<Vec<DirEntry>, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     let mut raw_entries: Vec<_> = std::fs::read_dir(path)
         .map_err(|e| format_fs_error(e, "scandir", path))?
         .filter_map(|entry| entry.ok())
@@ -432,6 +442,7 @@ fn op_howth_fs_stat(
     #[string] path: &str,
     follow_symlinks: bool,
 ) -> Result<FileStat, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     let syscall = if follow_symlinks { "stat" } else { "lstat" };
     let metadata = if follow_symlinks {
         std::fs::metadata(path).map_err(|e| format_fs_error(e, syscall, path))?
@@ -500,6 +511,7 @@ fn op_howth_fs_stat(
 /// Delete a file.
 #[op2(fast)]
 fn op_howth_fs_unlink(#[string] path: &str) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     std::fs::remove_file(path).map_err(|e| format_fs_error(e, "unlink", path))
 }
 
@@ -509,6 +521,7 @@ fn op_howth_fs_truncate(
     #[string] path: &str,
     #[bigint] len: u64,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     let file = std::fs::OpenOptions::new()
         .write(true)
         .open(path)
@@ -523,6 +536,7 @@ fn op_howth_fs_rmdir(
     #[string] path: &str,
     recursive: bool,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     if recursive {
         std::fs::remove_dir_all(path).map_err(|e| format_fs_error(e, "rmdir", path))
     } else {
@@ -536,6 +550,8 @@ fn op_howth_fs_rename(
     #[string] old_path: &str,
     #[string] new_path: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(old_path)?;
+    crate::permissions::get().check_write(new_path)?;
     std::fs::rename(old_path, new_path).map_err(|e| format_fs_error(e, "rename", old_path))
 }
 
@@ -545,6 +561,8 @@ fn op_howth_fs_copy(
     #[string] src: &str,
     #[string] dest: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_read(src)?;
+    crate::permissions::get().check_write(dest)?;
     std::fs::copy(src, dest)?;
     Ok(())
 }
@@ -555,6 +573,7 @@ fn op_howth_fs_append(
     #[string] path: &str,
     #[string] contents: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     use std::io::Write;
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -568,6 +587,7 @@ fn op_howth_fs_append(
 #[op2]
 #[string]
 fn op_howth_fs_read_bytes(#[string] path: &str) -> Result<String, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     let bytes = std::fs::read(path)?;
     // Return as base64 for efficient transfer
     Ok(base64_encode(&bytes))
@@ -579,6 +599,7 @@ fn op_howth_fs_write_bytes(
     #[string] path: &str,
     #[string] base64_data: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     let bytes = base64_decode(base64_data)?;
     std::fs::write(path, bytes)?;
     Ok(())
@@ -588,6 +609,7 @@ fn op_howth_fs_write_bytes(
 #[op2]
 #[string]
 fn op_howth_fs_realpath(#[string] path: &str) -> Result<String, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     dunce::canonicalize(path)
         .map(|p| p.to_string_lossy().to_string())
         .map_err(|e| e.into())
@@ -597,6 +619,7 @@ fn op_howth_fs_realpath(#[string] path: &str) -> Result<String, deno_core::error
 #[op2]
 #[string]
 fn op_howth_fs_readlink(#[string] path: &str) -> Result<String, deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     std::fs::read_link(path)
         .map(|p| p.to_string_lossy().to_string())
         .map_err(|e| format_fs_error(e, "readlink", path))
@@ -609,6 +632,7 @@ fn op_howth_fs_symlink(
     #[string] path: &str,
     #[string] link_type: &str,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     #[cfg(unix)]
     {
         let _ = link_type; // Suppress unused variable warning on Unix
@@ -633,6 +657,7 @@ fn op_howth_fs_chown(
     uid: u32,
     gid: u32,
 ) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
@@ -659,6 +684,7 @@ fn op_howth_fs_chown(
 /// Change file permissions (Unix only).
 #[op2(fast)]
 fn op_howth_fs_chmod(#[string] path: &str, mode: u32) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_write(path)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -678,6 +704,7 @@ fn op_howth_fs_chmod(#[string] path: &str, mode: u32) -> Result<(), deno_core::e
 /// Check file access permissions.
 #[op2(fast)]
 fn op_howth_fs_access(#[string] path: &str, mode: u32) -> Result<(), deno_core::error::AnyError> {
+    crate::permissions::get().check_read(path)?;
     let path = std::path::Path::new(path);
 
     // Mode flags: 0=exists, 1=execute, 2=write, 4=read
@@ -730,6 +757,23 @@ pub struct FileOpenResult {
 #[serde]
 fn op_howth_fs_open_fd(#[string] path: &str, #[string] flags: &str, mode: u32) -> FileOpenResult {
     use std::fs::OpenOptions;
+
+    // Any write/append/create/update flag needs write permission; plain reads need read.
+    let needs_write = matches!(
+        flags,
+        "r+" | "rs+" | "w" | "w+" | "wx+" | "a" | "a+" | "ax+"
+    );
+    let permit = if needs_write {
+        crate::permissions::get().check_write(path)
+    } else {
+        crate::permissions::get().check_read(path)
+    };
+    if let Err(e) = permit {
+        return FileOpenResult {
+            fd: 0,
+            error: Some(e.to_string()),
+        };
+    }
 
     let mut opts = OpenOptions::new();
 
@@ -1865,6 +1909,7 @@ async fn op_howth_dns_lookup(
     #[string] hostname: String,
     family: Option<u8>,
 ) -> Result<DnsLookupResult, deno_core::error::AnyError> {
+    crate::permissions::get().check_net_host(&hostname)?;
     let resolver = get_resolver();
 
     let response = resolver
@@ -2208,6 +2253,15 @@ fn op_howth_spawn_sync(
 ) -> SpawnSyncResult {
     use std::process::{Command, Stdio};
 
+    if let Err(e) = crate::permissions::get().check_run(command) {
+        return SpawnSyncResult {
+            status: -1,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: Some(e.to_string()),
+        };
+    }
+
     let opts = options.unwrap_or_default();
     let use_shell = opts.shell.unwrap_or(false);
 
@@ -2282,6 +2336,15 @@ fn op_howth_exec_sync(
     #[serde] options: Option<SpawnOptions>,
 ) -> SpawnSyncResult {
     use std::process::{Command, Stdio};
+
+    if let Err(e) = crate::permissions::get().check_run(command) {
+        return SpawnSyncResult {
+            status: -1,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: Some(e.to_string()),
+        };
+    }
 
     let opts = options.unwrap_or_default();
 
@@ -2391,6 +2454,14 @@ async fn op_howth_spawn_async(
     #[serde] options: Option<SpawnOptions>,
 ) -> SpawnAsyncResult {
     use std::process::Stdio;
+
+    if let Err(e) = crate::permissions::get().check_run(&command) {
+        return SpawnAsyncResult {
+            id: 0,
+            pid: 0,
+            error: Some(e.to_string()),
+        };
+    }
 
     let opts = options.unwrap_or_default();
     let use_shell = opts.shell.unwrap_or(false);
@@ -2717,6 +2788,7 @@ fn op_howth_http_listen(
     port: u16,
     #[string] hostname: String,
 ) -> Result<serde_json::Value, deno_core::error::AnyError> {
+    crate::permissions::get().check_net(&hostname, port)?;
     use http_body_util::BodyExt;
     use http_body_util::Full;
     use hyper::body::Bytes;
@@ -4843,6 +4915,7 @@ async fn op_howth_tcp_connect(
     #[string] host: String,
     port: u16,
 ) -> Result<serde_json::Value, deno_core::error::AnyError> {
+    crate::permissions::get().check_net(&host, port)?;
     let addr = format!("{}:{}", host, port);
     let stream = tokio::net::TcpStream::connect(&addr).await.map_err(|e| {
         deno_core::error::AnyError::msg(format!("TCP connect failed ({}): {}", addr, e))
@@ -5014,6 +5087,7 @@ async fn op_howth_tls_connect(
     #[string] _alpn: Option<String>,
     _reject_unauthorized: Option<bool>,
 ) -> Result<TlsConnectResult, deno_core::error::AnyError> {
+    crate::permissions::get().check_net(&host, port)?;
     let addr = format!("{}:{}", host, port);
 
     // Establish TCP connection first
@@ -5268,12 +5342,20 @@ fn op_howth_arch() -> &'static str {
 #[op2]
 #[string]
 fn op_howth_env_get(#[string] key: &str) -> Option<String> {
+    // A denied env var reads as unset.
+    if crate::permissions::get().check_env(key).is_err() {
+        return None;
+    }
     std::env::var(key).ok()
 }
 
 /// Set environment variable.
 #[op2(fast)]
 fn op_howth_env_set(#[string] key: &str, #[string] value: &str) {
+    // Silently ignore writes to env vars outside the grant.
+    if crate::permissions::get().check_env(key).is_err() {
+        return;
+    }
     std::env::set_var(key, value);
 }
 
@@ -5314,6 +5396,26 @@ pub struct FetchOptions {
     pub body: Option<String>,
 }
 
+/// Extract the host from an HTTP(S) URL for permission checks, without pulling
+/// in a URL parser: strip the scheme, then take up to the first `/`, `?`, `#`,
+/// drop any `user@` prefix and `:port` suffix.
+fn fetch_url_host(url: &str) -> Option<String> {
+    let rest = url
+        .split_once("://")
+        .map_or(url, |(_scheme, rest)| rest);
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(rest);
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = authority.rsplit_once(':').map_or(authority, |(h, _)| h);
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
 /// Fetch a URL (synchronous via blocking client, exposed as async op).
 /// Uses reqwest::blocking to make HTTP requests.
 #[op2(async)]
@@ -5322,6 +5424,11 @@ async fn op_howth_fetch(
     #[string] url: String,
     #[serde] options: Option<FetchOptions>,
 ) -> Result<FetchResponse, deno_core::error::AnyError> {
+    // Gate network access on the URL's host (port is implied by scheme).
+    if let Some(host) = fetch_url_host(&url) {
+        crate::permissions::get().check_net_host(&host)?;
+    }
+
     // Use std::thread::spawn since tokio spawn_blocking doesn't work well with current_thread
     let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -6088,6 +6195,12 @@ impl Runtime {
         // Set script args if provided (for process.argv)
         if let Some(args) = options.args {
             let _ = SCRIPT_ARGS.set(args);
+        }
+
+        // Install capability permissions before any user code runs. Absent =
+        // allow-all (Node-compatible); a sandbox is opt-in via CLI flags.
+        if let Some(permissions) = options.permissions {
+            crate::permissions::init(permissions);
         }
 
         let cwd = options


### PR DESCRIPTION
Add a Deno-style capability permission system to the runtime, allow-all by default to preserve Node compatibility. Users opt into a sandbox with --sandbox plus --allow-* grants, or selectively revoke with --deny-*.

- permissions.rs: Permissions struct (read/write/net/run/env scopes), stored in a process-global OnceLock (mirrors SCRIPT_ARGS), read via check_* helpers that return errors naming the flag to add.
- Gate boundary ops in runtime.rs: fs read/write, tcp/tls/http/dns/fetch, spawn/exec, env. Ops that don't return Result degrade (exists->false, env_get->None, open_fd/spawn->error struct).
- CLI: PermissionFlags flattened into `run`; build_permissions() converts them behind the native-runtime feature. Daemon/--node paths warn (not yet enforced).

Verified end-to-end: default = full Node access; --sandbox blocks fs/net/run; allowlists grant by path prefix / host / command. 9 unit tests.